### PR TITLE
Changed MAINTAINER instruction to LABEL due to deprecation

### DIFF
--- a/capitolul0/docker/Dockerfile
+++ b/capitolul0/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-MAINTAINER Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>
+LABEL org.opencontainers.image.authors="Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>"
 
 USER root
 

--- a/capitolul0/docker/Dockerfile-large
+++ b/capitolul0/docker/Dockerfile-large
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-MAINTAINER Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>
+LABEL org.opencontainers.image.authors="Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>"
 
 USER root
 

--- a/capitolul2/docker/Dockerfile
+++ b/capitolul2/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM kalilinux/kali-rolling
 
-MAINTAINER Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>
+LABEL org.opencontainers.image.authors="Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>"
 
 USER root
 

--- a/capitolul3/docker/Dockerfile-chap3
+++ b/capitolul3/docker/Dockerfile-chap3
@@ -1,6 +1,6 @@
 FROM snisioi/retele:2021
 
-MAINTAINER Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>
+LABEL org.opencontainers.image.authors="Sergiu Nisioi <sergiu.nisioi@fmi.unibuc.ro>"
 
 USER root
 


### PR DESCRIPTION
Updated every Dockerfile by changing the deprecated MAINTAINER instruction with LABEL.
About this deprecation: [https://docs.docker.com/engine/reference/builder/#maintainer-deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)